### PR TITLE
Public UV coords and loading with Image object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,14 +250,14 @@ Constructs a surface from an existing image. The function `ready()` will return 
 
 Parameter | Type | Description
 -|-|-
-image|`String`|A URL to a valid image file
+image|`String | Image`|A URL or Image object referring to a valid image file
 
 ### `Surface(image, width, height)`
 Construct a surface from an existing image. The width and height will be set from the beginning instead of after the image has been loaded.
 
 Parameter | Type | Description
 -|-|-
-image|`String`|A URL to a valid image file
+image|`String`|A URL or Image object referring to a valid image file
 width|`Number`|Width in pixels
 height|`Number`|Height in pixels
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Constructs a surface from an existing image. The function `ready()` will return 
 
 Parameter | Type | Description
 -|-|-
-image|`String` | `Image`|A URL or Image object referring to a valid image file
+image|`String` or `Image`|A URL or Image object referring to a valid image file
 
 ### `Surface(image, width, height)`
 Construct a surface from an existing image. The width and height will be set from the beginning instead of after the image has been loaded.

--- a/README.md
+++ b/README.md
@@ -391,10 +391,10 @@ Function | Description
 [`getHeight()`](#getheight-2)|Returns the sprite height
 [`getOriginX()`](#getoriginx)|Returns the X origin
 [`getOriginY()`](#getoriginy)|Returns the Y origin
-[`getUvLeft()`](#getuvleft)| Get the left UV coordinate.
-[`getUvTop()`](#getuvleft)| Get the top UV coordinate.
-[`getUvWidth()`](#getuvwidth)| Get the width of the sprite in UV space.
-[`getUvHeight()`](#getuvheight)| Get the height of the sprite in UV space
+[`getUvLeft()`](#getuvleft)| Returns the left UV coordinate.
+[`getUvTop()`](#getuvleft)| Returns the top UV coordinate.
+[`getUvWidth()`](#getuvwidth)| Returns the width of the sprite in UV space.
+[`getUvHeight()`](#getuvheight)| Returns the height of the sprite in UV space
 [`draw(x, y)`](#drawx-y-1)|Draws the sprite
 [`drawScaled(x, y, xScale, yScale)`](#drawscaledx-y-xscale-yscale-1)|Draws the sprite
 [`drawSheared(x, y, xShear, yShear)`](#drawshearedx-y-xshear-yshear-1)|Draws the sprite

--- a/README.md
+++ b/README.md
@@ -391,6 +391,10 @@ Function | Description
 [`getHeight()`](#getheight-2)|Returns the sprite height
 [`getOriginX()`](#getoriginx)|Returns the X origin
 [`getOriginY()`](#getoriginy)|Returns the Y origin
+[`getUvLeft()`](#getuvleft)| Get the left UV coordinate.
+[`getUvTop()`](#getuvleft)| Get the top UV coordinate.
+[`getUvWidth()`](#getuvwidth)| Get the width of the sprite in UV space.
+[`getUvHeight()`](#getuvheight)| Get the height of the sprite in UV space
 [`draw(x, y)`](#drawx-y-1)|Draws the sprite
 [`drawScaled(x, y, xScale, yScale)`](#drawscaledx-y-xscale-yscale-1)|Draws the sprite
 [`drawSheared(x, y, xShear, yShear)`](#drawshearedx-y-xshear-yshear-1)|Draws the sprite
@@ -442,6 +446,18 @@ Returns the X origin of this sprite's current frame.
 
 ### `getOriginY()`
 Returns the Y origin of this sprite's current frame.
+
+### `getUvLeft()`
+Returns the left UV coordinate.
+
+### `getUvRight()`
+Returns the top UV coordinate.
+
+### `getUvWidth()`
+Returns the width of the sprite in UV space.
+
+### `getUvHeight()` 
+Returns the height of the sprite in UV space
 
 ### `draw(x, y)`
 Draws this sprite on the currently bound target.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Constructs a surface from an existing image. The function `ready()` will return 
 
 Parameter | Type | Description
 -|-|-
-image|`String | Image`|A URL or Image object referring to a valid image file
+image|`String` | `Image`|A URL or Image object referring to a valid image file
 
 ### `Surface(image, width, height)`
 Construct a surface from an existing image. The width and height will be set from the beginning instead of after the image has been loaded.

--- a/myr.js
+++ b/myr.js
@@ -322,18 +322,13 @@ let Myr = function(canvasElement) {
         }
         else {
             const image = new Image();
-            
-            if(arguments[2] !== undefined) {
-                width = arguments[1];
-                height = arguments[2];
-            }
-            
+
             image.onload = () => {
                 if(width === 0 || height === 0) {
                     width = image.width;
                     height = image.height;
                 }
-                
+
                 gl.activeTexture(TEXTURE_EDITING);
                 gl.bindTexture(gl.TEXTURE_2D, texture);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
@@ -344,13 +339,26 @@ let Myr = function(canvasElement) {
                     frame[7] /= width;
                     frame[8] /= height;
                 }
-                
+
                 ready = true;
             };
-            
-            image.crossOrigin = "Anonymous";
-            image.src = arguments[0];
-            
+
+            const source = arguments[0];
+            if (source instanceof Image) {
+                image.crossOrigin = source.crossOrigin;
+                image.src = source.src;
+                image.width = source.width;
+                image.height = source.height;
+            } else {
+                image.crossOrigin = "Anonymous";
+                image.src = source;
+            }
+
+            if (arguments[2] !== undefined) {
+                width = arguments[1];
+                height = arguments[2];
+            }
+
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(4));
         }
         

--- a/myr.js
+++ b/myr.js
@@ -286,10 +286,10 @@ let Myr = function(canvasElement) {
         };
 
         this._getTexture = () => texture;
-        this._getUvLeft = () => 0;
-        this._getUvTop = () => 0;
-        this._getUvWidth = () => 1;
-        this._getUvHeight = () => 1;
+        this.getUvLeft = () => 0;
+        this.getUvTop = () => 0;
+        this.getUvWidth = () => 1;
+        this.getUvHeight = () => 1;
 
         this.getWidth = () => width;
         this.getHeight = () => height;
@@ -383,10 +383,10 @@ let Myr = function(canvasElement) {
         };
 
         this._getTexture = () => getFrame()[0];
-        this._getUvLeft = () => getFrame()[5];
-        this._getUvTop = () => getFrame()[6];
-        this._getUvWidth = () => getFrame()[7];
-        this._getUvHeight = () => getFrame()[8];
+        this.getUvLeft = () => getFrame()[5];
+        this.getUvTop = () => getFrame()[6];
+        this.getUvWidth = () => getFrame()[7];
+        this.getUvHeight = () => getFrame()[8];
         this.setFrame = index => frame = index;
         this.getFrame = () => frame;
         this.isFinished = () => getFrame()[9] < 0;
@@ -471,49 +471,49 @@ let Myr = function(canvasElement) {
         draw: function(x, y) {
             this._prepareDraw();
 
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDraw(x, y, this.getWidth(), this.getHeight());
         },
 
         drawScaled: function(x, y, xScale, yScale) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDraw(x, y, this.getWidth() * xScale, this.getHeight() * yScale);
         },
 
         drawSheared: function(x, y, xShear, yShear) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDrawSheared(x, y, this.getWidth(), this.getHeight(), xShear, yShear);
         },
 
         drawRotated: function(x, y, angle) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDrawRotated(x, y, this.getWidth(), this.getHeight(), angle);
         },
 
         drawScaledRotated: function(x, y, xScale, yScale, angle) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDrawRotated(x, y, this.getWidth() * xScale, this.getHeight() * yScale, angle);
         },
 
         drawTransformed: function(transform) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDrawTransform(transform, this.getWidth(), this.getHeight());
         },
 
         drawTransformedAt: function(x, y, transform) {
             this._prepareDraw();
             
-            setAttributesUv(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight());
+            setAttributesUv(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight());
             setAttributesDrawTransformAt(x, y, transform, this.getWidth(), this.getHeight());
         },
 
@@ -523,7 +523,7 @@ let Myr = function(canvasElement) {
             const wf = 1 / this.getWidth();
             const hf = 1 / this.getHeight();
             
-            setAttributesUvPart(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight(), left * wf, top * hf, w * wf, h * hf);
+            setAttributesUvPart(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight(), left * wf, top * hf, w * wf, h * hf);
             setAttributesDraw(x, y, w, h);
         },
 
@@ -533,7 +533,7 @@ let Myr = function(canvasElement) {
             const wf = 1 / this.getWidth();
             const hf = 1 / this.getHeight();
             
-            setAttributesUvPart(this._getUvLeft(), this._getUvTop(), this._getUvWidth(), this._getUvHeight(), left * wf, top * hf, w * wf, h * hf);
+            setAttributesUvPart(this.getUvLeft(), this.getUvTop(), this.getUvWidth(), this.getUvHeight(), left * wf, top * hf, w * wf, h * hf);
             setAttributesDrawTransform(transform, w, h);
         }
     };


### PR DESCRIPTION
It seemed cleaner to allow loading a surface from a pre-existing Image Element than letting myr.js return its own image object (especially as you would want to do this only when you already want a html version in your webpage). Problems related to retrieving a new image object from a _generated_ surface are better solved using a `getPixelBuffer` solution in any case.